### PR TITLE
Use toString instead of stringify

### DIFF
--- a/src/html.js
+++ b/src/html.js
@@ -36,7 +36,7 @@ function renderValue(key) {
         if ('render' in key) {
             s = key.render()
         } else {
-            s = stringify(key)
+            s = key.toString()
         }
     } else {
         s = key.toString()


### PR DESCRIPTION
Not sure I should merge this, but we need a way to stringify objects within tags and objects outside tags. 

Because it currently renders things like `Decimal` objects wrapped in quotes.